### PR TITLE
Lazily attach the svg filter to the page

### DIFF
--- a/chrome/js/filters.js
+++ b/chrome/js/filters.js
@@ -1,10 +1,23 @@
+var filter = null;
 var xhr = new XMLHttpRequest()
 xhr.open('GET', chrome.extension.getURL('img/filters.svg'))
 xhr.addEventListener('load', function(e) {
-  var filter = xhr.responseXML.documentElement
+  filter = xhr.responseXML.documentElement
   filter.style.display = 'none'
   filter.width = 0
   filter.height = 0
-  document.body.appendChild(filter)
 })
 xhr.send()
+
+function applyFilter(){
+    document.body.appendChild(filter);
+}
+
+chrome.runtime.onMessage.addListener(
+  function(request, sender, sendReponse){
+    if (request.method=="load"){
+      applyFilter();
+      sendResponse(true);
+    }
+  }
+)

--- a/chrome/js/popup.js
+++ b/chrome/js/popup.js
@@ -34,7 +34,15 @@ Object.keys(vision).forEach(function (el) {
 
 document.body.appendChild(ul)
 
+var filterLoaded = false;
 function handler(e) {
+  if (!filterLoaded){
+    chrome.tabs.query({active:true,currentWindow:true},function(tabs){
+      chrome.tabs.sendMessage(tabs[0].id, {method:"load"}, function(response){
+        filterLoaded = response;
+      });
+    });
+  }
   current = this.dataset['type']
   $.all('li').forEach(function(li) {
     li.classList.remove('current')


### PR DESCRIPTION
the content script loads the svg but doesn't attach it until the extension window tells it to. When you select a colour profile for the first time the extension will tell the content script to load.

This prevents the extension from interfering with pages until actually used. This fixes the known issue with bitbucket in #3 and prevents further issues.